### PR TITLE
Source not needed inside the container

### DIFF
--- a/sites/beyond-chocolate/Dockerfile-node
+++ b/sites/beyond-chocolate/Dockerfile-node
@@ -6,7 +6,4 @@ RUN set -eux; \
 
 WORKDIR /var/www/html
 
-COPY . .
-COPY --chown=node:node . .
-
 USER node

--- a/sites/beyond-chocolate/Dockerfile-php
+++ b/sites/beyond-chocolate/Dockerfile-php
@@ -27,7 +27,4 @@ RUN set -eux; \
 
 COPY --from=composer:2.0 /usr/bin/composer /usr/bin/composer
 
-COPY . .
-COPY --chown=akvo:akvo . .
-
 USER akvo


### PR DESCRIPTION
The containers are not deployed at all in production, so there is no need to copy the sources inside the container, as Docker-Compose mounts the "live" directory of the host in the same location.

Doing a CP can take several minutes if you are restarting the containers, and docker layer is not going to help if you have touched any of the files in the project.