### PR TITLE
[#392] Add uuid to save data pushApi function

### DIFF
--- a/sites/akvo-flow-web/src/component/Overview.js
+++ b/sites/akvo-flow-web/src/component/Overview.js
@@ -96,7 +96,8 @@ class Overview extends Component {
                 answer: parseAnswer(answer),
             }
         });
-        const file = surveyName + "-" + uuid;
+        const filename = surveyName.replace(' ', '-');
+        const file = filename + "-" + uuid;
         axios.post(API_URL + 'download', {data: data, name:file})
             .then(res => {
                 window.open(API_URL + 'static/excel/' + file + ".xlsx");

--- a/sites/akvo-flow-web/src/component/Submit.js
+++ b/sites/akvo-flow-web/src/component/Submit.js
@@ -94,6 +94,7 @@ class Submit extends Component {
                 form_instance_id: saveData.instanceName,
                 form_instance_url: formInstanceUrl,
                 submitted: submitted,
+                uuid: (submitted) ? localStorage.getItem('_dataPointId') : null,
                 updated_at: new Date(),
             }
         }


### PR DESCRIPTION
- We will show submitted data for submission in gisco and uuid required to map submitted data from flow with gisco database
- Also there was some failed download for some survey  from Overview, like <https://tech-consultancy.akvotest.org/akvo-flow-web-api/static/excel/D-Civil%20Society-9341-555a-4b99.xlsx>, I think that's because the filename contains space, so I replace space with ' - '